### PR TITLE
Switching from GHCR to DockerHub

### DIFF
--- a/ww-sra-star-options.json
+++ b/ww-sra-star-options.json
@@ -1,0 +1,10 @@
+{
+    "workflow_failure_mode": "ContinueWhilePossible",
+    "write_to_cache": true,
+    "read_from_cache": true,
+    "default_runtime_attributes": {
+        "maxRetries": 1
+    },
+    "final_workflow_outputs_dir": "test-output/",
+    "use_relative_output_paths": true
+}

--- a/ww-sra-star.wdl
+++ b/ww-sra-star.wdl
@@ -102,7 +102,7 @@ task fastqdump {
 
   runtime {
     memory: 2 * ncpu + " GB"
-    docker: "ghcr.io/getwilds/pfastqdump:0.6.7"
+    docker: "getwilds/pfastqdump:0.6.7"
     cpu: ncpu
   }
 
@@ -157,7 +157,7 @@ task STARalignTwoPass {
   }
 
   runtime {
-    docker: "ghcr.io/getwilds/star:2.7.6a"
+    docker: "getwilds/star:2.7.6a"
     memory: 2 * cpu + "GB"
     cpu: cpu
   }


### PR DESCRIPTION
## Description
- Switching Docker images from GHCR to DockerHub because of call caching issues
- Also adding options json for usability

## Related Issue
- Fixes #2 